### PR TITLE
feat: replace medium article cards with blog-post-workflow action

### DIFF
--- a/.github/workflows/blog-posts.yml
+++ b/.github/workflows/blog-posts.yml
@@ -1,0 +1,20 @@
+name: Latest blog posts
+on:
+  schedule:
+    - cron: '0 9 1,15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme-with-blog:
+    name: Update README with latest blog posts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/blog-post-workflow@v1
+        with:
+          feed_list: "https://medium.com/feed/@ethanj129"
+          max_post_count: 4
+          comment_tag_name: "BLOG-POST-LIST"

--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@
 
 ✏️ &nbsp;*Recent blog posts*:
 
-<a target="_blank" href="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/0"><img src="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/0" alt="Recent article #1"></a>
-<a target="_blank" href="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/1"><img src="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/1" alt="Recent article #2"></a>
-<a target="_blank" href="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/2"><img src="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/2" alt="Recent article #3"></a>
-<a target="_blank" href="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/3"><img src="https://github-readme-medium-recent-article.vercel.app/medium/@ethanj129/3" alt="Recent article #4"></a>
+<!-- BLOG-POST-LIST:START -->
+<!-- BLOG-POST-LIST:END -->
 
 
 🚀 &nbsp;*Currently building*:


### PR DESCRIPTION
This pull request sets up an automated workflow to keep the list of recent blog posts in the `README.md` up to date. It replaces the previous static approach with a dynamic, GitHub Actions-based solution that fetches the latest posts from the specified Medium feed and updates the README automatically.

**Automation of blog post updates:**

* Added a new GitHub Actions workflow (`.github/workflows/blog-posts.yml`) that runs on a schedule and on manual dispatch to update the README with the latest blog posts from the Medium feed using the `blog-post-workflow` action.

**README changes:**

* Replaced hardcoded blog post links in `README.md` with special comment tags (`<!-- BLOG-POST-LIST:START -->` and `<!-- BLOG-POST-LIST:END -->`) to enable automatic insertion of the latest blog posts by the workflow.